### PR TITLE
Move `Arc` into the LibraryImpl

### DIFF
--- a/windows-projfs/src/aligned_buffer.rs
+++ b/windows-projfs/src/aligned_buffer.rs
@@ -1,7 +1,4 @@
-use std::{
-    ffi::c_void,
-    sync::Arc,
-};
+use std::ffi::c_void;
 
 use windows::Win32::Storage::ProjectedFileSystem::PRJ_NAMESPACE_VIRTUALIZATION_CONTEXT;
 
@@ -11,7 +8,7 @@ use crate::library::{
 };
 
 pub struct PrjAlignedBuffer {
-    library: Arc<LibraryImpl>,
+    library: LibraryImpl,
 
     length: usize,
     raw_buffer: *mut c_void,
@@ -19,7 +16,7 @@ pub struct PrjAlignedBuffer {
 
 impl PrjAlignedBuffer {
     pub fn allocate(
-        library: Arc<LibraryImpl>,
+        library: LibraryImpl,
         context: PRJ_NAMESPACE_VIRTUALIZATION_CONTEXT,
         length: usize,
     ) -> Option<Self> {

--- a/windows-projfs/src/aligned_buffer.rs
+++ b/windows-projfs/src/aligned_buffer.rs
@@ -5,10 +5,13 @@ use std::{
 
 use windows::Win32::Storage::ProjectedFileSystem::PRJ_NAMESPACE_VIRTUALIZATION_CONTEXT;
 
-use crate::library::ProjectedFSLibrary;
+use crate::library::{
+    LibraryImpl,
+    ProjectedFSLibrary,
+};
 
 pub struct PrjAlignedBuffer {
-    library: Arc<dyn ProjectedFSLibrary>,
+    library: Arc<LibraryImpl>,
 
     length: usize,
     raw_buffer: *mut c_void,
@@ -16,7 +19,7 @@ pub struct PrjAlignedBuffer {
 
 impl PrjAlignedBuffer {
     pub fn allocate(
-        library: Arc<dyn ProjectedFSLibrary>,
+        library: Arc<LibraryImpl>,
         context: PRJ_NAMESPACE_VIRTUALIZATION_CONTEXT,
         length: usize,
     ) -> Option<Self> {

--- a/windows-projfs/src/fs.rs
+++ b/windows-projfs/src/fs.rs
@@ -11,7 +11,6 @@ use std::{
         PathBuf,
     },
     rc::Rc,
-    sync::Arc,
 };
 
 use parking_lot::Mutex;
@@ -135,7 +134,7 @@ impl DirectoryIteration {
 
 pub type RawProjectionContext = Mutex<ProjectionContext>;
 pub struct ProjectionContext {
-    library: Arc<library::LibraryImpl>,
+    library: library::LibraryImpl,
     source: Box<dyn ProjectedFileSystemSource>,
     directory_enumerations: BTreeMap<u128, DirectoryIteration>,
 }
@@ -145,7 +144,7 @@ impl ProjectionContext {
         let old_enumeration = self.directory_enumerations.insert(
             id,
             DirectoryIteration::from_unsorted(
-                &*self.library,
+                &self.library,
                 id,
                 self.source.list_directory(&target),
             ),
@@ -162,7 +161,7 @@ impl ProjectionContext {
 }
 
 pub struct ProjectedFileSystem {
-    library: Arc<library::LibraryImpl>,
+    library: library::LibraryImpl,
     instance_id: GUID,
 
     raw_context: *mut RawProjectionContext,

--- a/windows-projfs/src/fs.rs
+++ b/windows-projfs/src/fs.rs
@@ -18,6 +18,7 @@ use parking_lot::Mutex;
 use windows::{
     core::{
         GUID,
+        HSTRING,
         PCWSTR,
     },
     Win32::Storage::ProjectedFileSystem::{
@@ -43,6 +44,7 @@ use windows::{
 
 use crate::{
     library::{
+        self,
         load_library,
         ProjectedFSLibrary,
     },
@@ -83,7 +85,7 @@ struct DirectoryIteration {
 
 impl DirectoryIteration {
     pub fn from_unsorted(
-        library: &dyn ProjectedFSLibrary,
+        library: &impl ProjectedFSLibrary,
         id: u128,
         mut entries: Vec<DirectoryEntry>,
     ) -> Self {
@@ -133,7 +135,7 @@ impl DirectoryIteration {
 
 pub type RawProjectionContext = Mutex<ProjectionContext>;
 pub struct ProjectionContext {
-    library: Arc<dyn ProjectedFSLibrary>,
+    library: Arc<library::LibraryImpl>,
     source: Box<dyn ProjectedFileSystemSource>,
     directory_enumerations: BTreeMap<u128, DirectoryIteration>,
 }
@@ -160,7 +162,7 @@ impl ProjectionContext {
 }
 
 pub struct ProjectedFileSystem {
-    library: Arc<dyn ProjectedFSLibrary>,
+    library: Arc<library::LibraryImpl>,
     instance_id: GUID,
 
     raw_context: *mut RawProjectionContext,
@@ -171,17 +173,11 @@ static EMPTY_U16_STRING: &[u16] = &[0];
 impl ProjectedFileSystem {
     pub fn new(root: &Path, source: impl ProjectedFileSystemSource + 'static) -> Result<Self> {
         let instance_id = GUID::new()?;
-        let mut root_encoded = root.to_string_lossy().encode_utf16().collect::<Vec<_>>();
-        root_encoded.push(0);
+        let root = HSTRING::from(root);
 
         let library = load_library()?;
         unsafe {
-            library.prj_mark_directory_as_placeholder(
-                PCWSTR(root_encoded.as_ptr()),
-                PCWSTR::null(),
-                None,
-                &instance_id,
-            )
+            library.prj_mark_directory_as_placeholder(&root, PCWSTR::null(), None, &instance_id)
         }
         .map_err(Error::MarkProjectionRoot)?;
 
@@ -234,7 +230,7 @@ impl ProjectedFileSystem {
 
             let result = unsafe {
                 library.prj_start_virtualizing(
-                    PCWSTR(root_encoded.as_ptr()),
+                    &root,
                     &*callbacks,
                     Some(raw_context as *const c_void),
                     Some(&options),
@@ -342,6 +338,7 @@ mod native {
     };
     use crate::{
         aligned_buffer::PrjAlignedBuffer,
+        library::ProjectedFSLibrary,
         utils::io_result_to_hresult,
         DirectoryEntry,
         FileCloseAction,

--- a/windows-projfs/src/library.rs
+++ b/windows-projfs/src/library.rs
@@ -2,6 +2,7 @@ use std::ffi::c_void;
 
 use windows::{
     core::{
+        Param,
         GUID,
         PCWSTR,
     },
@@ -25,38 +26,51 @@ pub trait ProjectedFSLibrary {
     ) -> *mut c_void;
 
     unsafe fn prj_free_aligned_buffer(&self, buffer: *const c_void);
-    unsafe fn prj_file_name_compare(&self, filename1: PCWSTR, filename2: PCWSTR) -> i32;
+    unsafe fn prj_file_name_compare<P0, P1>(&self, filename1: P0, filename2: P1) -> i32
+    where
+        P0: Param<PCWSTR>,
+        P1: Param<PCWSTR>;
 
-    unsafe fn prj_file_name_match(&self, filenametocheck: PCWSTR, pattern: PCWSTR) -> bool;
+    unsafe fn prj_file_name_match<P0, P1>(&self, filenametocheck: P0, pattern: P1) -> bool
+    where
+        P0: Param<PCWSTR>,
+        P1: Param<PCWSTR>;
 
-    unsafe fn prj_mark_directory_as_placeholder(
+    unsafe fn prj_mark_directory_as_placeholder<P0, P1>(
         &self,
-        rootpathname: PCWSTR,
-        targetpathname: PCWSTR,
+        rootpathname: P0,
+        targetpathname: P1,
         versioninfo: Option<*const PRJ_PLACEHOLDER_VERSION_INFO>,
         virtualizationinstanceid: *const GUID,
-    ) -> windows::core::Result<()>;
+    ) -> windows::core::Result<()>
+    where
+        P0: Param<PCWSTR>,
+        P1: Param<PCWSTR>;
 
-    unsafe fn prj_start_virtualizing(
+    unsafe fn prj_start_virtualizing<P0>(
         &self,
-        virtualizationrootpath: PCWSTR,
+        virtualizationrootpath: P0,
         callbacks: *const PRJ_CALLBACKS,
         instancecontext: Option<*const ::core::ffi::c_void>,
         options: Option<*const PRJ_STARTVIRTUALIZING_OPTIONS>,
-    ) -> windows::core::Result<PRJ_NAMESPACE_VIRTUALIZATION_CONTEXT>;
+    ) -> windows::core::Result<PRJ_NAMESPACE_VIRTUALIZATION_CONTEXT>
+    where
+        P0: Param<PCWSTR>;
 
     unsafe fn prj_stop_virtualizing(
         &self,
         namespacevirtualizationcontext: PRJ_NAMESPACE_VIRTUALIZATION_CONTEXT,
     );
 
-    unsafe fn prj_fill_dir_entry_buffer2(
+    unsafe fn prj_fill_dir_entry_buffer2<P0>(
         &self,
         direntrybufferhandle: PRJ_DIR_ENTRY_BUFFER_HANDLE,
-        filename: PCWSTR,
+        filename: P0,
         filebasicinfo: Option<*const PRJ_FILE_BASIC_INFO>,
         extendedinfo: Option<*const PRJ_EXTENDED_INFO>,
-    ) -> windows::core::Result<()>;
+    ) -> windows::core::Result<()>
+    where
+        P0: Param<PCWSTR>;
 
     unsafe fn prj_write_file_data(
         &self,
@@ -67,23 +81,29 @@ pub trait ProjectedFSLibrary {
         length: u32,
     ) -> windows::core::Result<()>;
 
-    unsafe fn prj_write_placeholder_info(
+    unsafe fn prj_write_placeholder_info<P0>(
         &self,
         namespacevirtualizationcontext: PRJ_NAMESPACE_VIRTUALIZATION_CONTEXT,
-        destinationfilename: PCWSTR,
+        destinationfilename: P0,
         placeholderinfo: *const PRJ_PLACEHOLDER_INFO,
         placeholderinfosize: u32,
-    ) -> windows::core::Result<()>;
+    ) -> windows::core::Result<()>
+    where
+        P0: Param<PCWSTR>;
 
-    unsafe fn prj_write_placeholder_info2(
+    unsafe fn prj_write_placeholder_info2<P0>(
         &self,
         namespacevirtualizationcontext: PRJ_NAMESPACE_VIRTUALIZATION_CONTEXT,
-        destinationfilename: PCWSTR,
+        destinationfilename: P0,
         placeholderinfo: *const PRJ_PLACEHOLDER_INFO,
         placeholderinfosize: u32,
         extendedinfo: ::core::option::Option<*const PRJ_EXTENDED_INFO>,
-    ) -> windows::core::Result<()>;
+    ) -> windows::core::Result<()>
+    where
+        P0: Param<PCWSTR>;
 }
+
+pub use lib_impl::Library as LibraryImpl;
 
 #[cfg(not(feature = "dynamic-import"))]
 mod lib_impl {
@@ -94,6 +114,7 @@ mod lib_impl {
 
     use windows::{
         core::{
+            Param,
             GUID,
             PCWSTR,
         },
@@ -112,6 +133,7 @@ mod lib_impl {
     use super::ProjectedFSLibrary;
 
     pub struct StaticallyLinkedLibrary;
+    pub use StaticallyLinkedLibrary as Library;
 
     impl ProjectedFSLibrary for StaticallyLinkedLibrary {
         unsafe fn prj_allocate_aligned_buffer(
@@ -128,23 +150,35 @@ mod lib_impl {
             PrjFreeAlignedBuffer(buffer)
         }
 
-        unsafe fn prj_file_name_compare(&self, filename1: PCWSTR, filename2: PCWSTR) -> i32 {
+        unsafe fn prj_file_name_compare<P0, P1>(&self, filename1: P0, filename2: P1) -> i32
+        where
+            P0: Param<PCWSTR>,
+            P1: Param<PCWSTR>,
+        {
             use windows::Win32::Storage::ProjectedFileSystem::PrjFileNameCompare;
             PrjFileNameCompare(filename1, filename2)
         }
 
-        unsafe fn prj_file_name_match(&self, filenametocheck: PCWSTR, pattern: PCWSTR) -> bool {
+        unsafe fn prj_file_name_match<P0, P1>(&self, filenametocheck: P0, pattern: P1) -> bool
+        where
+            P0: Param<PCWSTR>,
+            P1: Param<PCWSTR>,
+        {
             use windows::Win32::Storage::ProjectedFileSystem::PrjFileNameMatch;
             PrjFileNameMatch(filenametocheck, pattern)
         }
 
-        unsafe fn prj_mark_directory_as_placeholder(
+        unsafe fn prj_mark_directory_as_placeholder<P0, P1>(
             &self,
-            rootpathname: PCWSTR,
-            targetpathname: PCWSTR,
+            rootpathname: P0,
+            targetpathname: P1,
             versioninfo: Option<*const PRJ_PLACEHOLDER_VERSION_INFO>,
             virtualizationinstanceid: *const GUID,
-        ) -> windows::core::Result<()> {
+        ) -> windows::core::Result<()>
+        where
+            P0: Param<PCWSTR>,
+            P1: Param<PCWSTR>,
+        {
             use windows::Win32::Storage::ProjectedFileSystem::PrjMarkDirectoryAsPlaceholder;
             PrjMarkDirectoryAsPlaceholder(
                 rootpathname,
@@ -154,13 +188,16 @@ mod lib_impl {
             )
         }
 
-        unsafe fn prj_start_virtualizing(
+        unsafe fn prj_start_virtualizing<P0>(
             &self,
-            virtualizationrootpath: PCWSTR,
+            virtualizationrootpath: P0,
             callbacks: *const PRJ_CALLBACKS,
             instancecontext: Option<*const core::ffi::c_void>,
             options: Option<*const PRJ_STARTVIRTUALIZING_OPTIONS>,
-        ) -> windows::core::Result<PRJ_NAMESPACE_VIRTUALIZATION_CONTEXT> {
+        ) -> windows::core::Result<PRJ_NAMESPACE_VIRTUALIZATION_CONTEXT>
+        where
+            P0: Param<PCWSTR>,
+        {
             use windows::Win32::Storage::ProjectedFileSystem::PrjStartVirtualizing;
             PrjStartVirtualizing(virtualizationrootpath, callbacks, instancecontext, options)
         }
@@ -173,13 +210,16 @@ mod lib_impl {
             PrjStopVirtualizing(namespacevirtualizationcontext)
         }
 
-        unsafe fn prj_fill_dir_entry_buffer2(
+        unsafe fn prj_fill_dir_entry_buffer2<P0>(
             &self,
             direntrybufferhandle: PRJ_DIR_ENTRY_BUFFER_HANDLE,
-            filename: PCWSTR,
+            filename: P0,
             filebasicinfo: Option<*const PRJ_FILE_BASIC_INFO>,
             extendedinfo: Option<*const PRJ_EXTENDED_INFO>,
-        ) -> windows::core::Result<()> {
+        ) -> windows::core::Result<()>
+        where
+            P0: Param<PCWSTR>,
+        {
             use windows::Win32::Storage::ProjectedFileSystem::PrjFillDirEntryBuffer2;
             PrjFillDirEntryBuffer2(direntrybufferhandle, filename, filebasicinfo, extendedinfo)
         }
@@ -202,13 +242,16 @@ mod lib_impl {
             )
         }
 
-        unsafe fn prj_write_placeholder_info(
+        unsafe fn prj_write_placeholder_info<P0>(
             &self,
             namespacevirtualizationcontext: PRJ_NAMESPACE_VIRTUALIZATION_CONTEXT,
-            destinationfilename: PCWSTR,
+            destinationfilename: P0,
             placeholderinfo: *const PRJ_PLACEHOLDER_INFO,
             placeholderinfosize: u32,
-        ) -> windows::core::Result<()> {
+        ) -> windows::core::Result<()>
+        where
+            P0: Param<PCWSTR>,
+        {
             use windows::Win32::Storage::ProjectedFileSystem::PrjWritePlaceholderInfo;
             PrjWritePlaceholderInfo(
                 namespacevirtualizationcontext,
@@ -218,14 +261,17 @@ mod lib_impl {
             )
         }
 
-        unsafe fn prj_write_placeholder_info2(
+        unsafe fn prj_write_placeholder_info2<P0>(
             &self,
             namespacevirtualizationcontext: PRJ_NAMESPACE_VIRTUALIZATION_CONTEXT,
-            destinationfilename: PCWSTR,
+            destinationfilename: P0,
             placeholderinfo: *const PRJ_PLACEHOLDER_INFO,
             placeholderinfosize: u32,
             extendedinfo: core::option::Option<*const PRJ_EXTENDED_INFO>,
-        ) -> windows::core::Result<()> {
+        ) -> windows::core::Result<()>
+        where
+            P0: Param<PCWSTR>,
+        {
             use windows::Win32::Storage::ProjectedFileSystem::PrjWritePlaceholderInfo2;
             PrjWritePlaceholderInfo2(
                 namespacevirtualizationcontext,
@@ -237,7 +283,7 @@ mod lib_impl {
         }
     }
 
-    pub fn load_library() -> crate::Result<Arc<dyn ProjectedFSLibrary>> {
+    pub fn load_library() -> crate::Result<Arc<StaticallyLinkedLibrary>> {
         Ok(Arc::new(StaticallyLinkedLibrary))
     }
 }
@@ -252,6 +298,7 @@ mod lib_impl {
 
     use windows::{
         core::{
+            Param,
             GUID,
             HRESULT,
             PCWSTR,
@@ -325,6 +372,8 @@ mod lib_impl {
         }
     }
 
+    pub use DynamicallyLoadedLibrary as Library;
+
     impl ProjectedFSLibrary for DynamicallyLoadedLibrary {
         unsafe fn prj_allocate_aligned_buffer(
             &self,
@@ -338,40 +387,55 @@ mod lib_impl {
             (self.PrjFreeAlignedBuffer)(buffer)
         }
 
-        unsafe fn prj_file_name_compare(&self, filename1: PCWSTR, filename2: PCWSTR) -> i32 {
-            (self.PrjFileNameCompare)(filename1, filename2)
+        unsafe fn prj_file_name_compare<P0, P1>(&self, filename1: P0, filename2: P1) -> i32
+        where
+            P0: Param<PCWSTR>,
+            P1: Param<PCWSTR>,
+        {
+            (self.PrjFileNameCompare)(filename1.param().abi(), filename2.param().abi())
         }
 
-        unsafe fn prj_file_name_match(&self, filenametocheck: PCWSTR, pattern: PCWSTR) -> bool {
-            (self.PrjFileNameMatch)(filenametocheck, pattern)
+        unsafe fn prj_file_name_match<P0, P1>(&self, filenametocheck: P0, pattern: P1) -> bool
+        where
+            P0: Param<PCWSTR>,
+            P1: Param<PCWSTR>,
+        {
+            (self.PrjFileNameMatch)(filenametocheck.param().abi(), pattern.param().abi())
         }
 
-        unsafe fn prj_mark_directory_as_placeholder(
+        unsafe fn prj_mark_directory_as_placeholder<P0, P1>(
             &self,
-            rootpathname: PCWSTR,
-            targetpathname: PCWSTR,
+            rootpathname: P0,
+            targetpathname: P1,
             versioninfo: Option<*const PRJ_PLACEHOLDER_VERSION_INFO>,
             virtualizationinstanceid: *const GUID,
-        ) -> windows::core::Result<()> {
+        ) -> windows::core::Result<()>
+        where
+            P0: Param<PCWSTR>,
+            P1: Param<PCWSTR>,
+        {
             (self.PrjMarkDirectoryAsPlaceholder)(
-                rootpathname,
-                targetpathname,
+                rootpathname.param().abi(),
+                targetpathname.param().abi(),
                 versioninfo.unwrap_or(ptr::null()),
                 virtualizationinstanceid,
             )
             .ok()
         }
 
-        unsafe fn prj_start_virtualizing(
+        unsafe fn prj_start_virtualizing<P0>(
             &self,
-            virtualizationrootpath: PCWSTR,
+            virtualizationrootpath: P0,
             callbacks: *const PRJ_CALLBACKS,
             instancecontext: Option<*const core::ffi::c_void>,
             options: Option<*const PRJ_STARTVIRTUALIZING_OPTIONS>,
-        ) -> windows::core::Result<PRJ_NAMESPACE_VIRTUALIZATION_CONTEXT> {
+        ) -> windows::core::Result<PRJ_NAMESPACE_VIRTUALIZATION_CONTEXT>
+        where
+            P0: Param<PCWSTR>,
+        {
             let mut result = ::std::mem::zeroed();
             (self.PrjStartVirtualizing)(
-                virtualizationrootpath,
+                virtualizationrootpath.param().abi(),
                 callbacks,
                 instancecontext.unwrap_or(ptr::null()),
                 options.unwrap_or(ptr::null()),
@@ -387,16 +451,19 @@ mod lib_impl {
             (self.PrjStopVirtualizing)(namespacevirtualizationcontext)
         }
 
-        unsafe fn prj_fill_dir_entry_buffer2(
+        unsafe fn prj_fill_dir_entry_buffer2<P0>(
             &self,
             direntrybufferhandle: PRJ_DIR_ENTRY_BUFFER_HANDLE,
-            filename: PCWSTR,
+            filename: P0,
             filebasicinfo: Option<*const PRJ_FILE_BASIC_INFO>,
             extendedinfo: Option<*const PRJ_EXTENDED_INFO>,
-        ) -> windows::core::Result<()> {
+        ) -> windows::core::Result<()>
+        where
+            P0: Param<PCWSTR>,
+        {
             (self.PrjFillDirEntryBuffer2)(
                 direntrybufferhandle,
-                filename,
+                filename.param().abi(),
                 filebasicinfo.unwrap_or(ptr::null()),
                 extendedinfo.unwrap_or(ptr::null()),
             )
@@ -421,33 +488,39 @@ mod lib_impl {
             .ok()
         }
 
-        unsafe fn prj_write_placeholder_info(
+        unsafe fn prj_write_placeholder_info<P0>(
             &self,
             namespacevirtualizationcontext: PRJ_NAMESPACE_VIRTUALIZATION_CONTEXT,
-            destinationfilename: PCWSTR,
+            destinationfilename: P0,
             placeholderinfo: *const PRJ_PLACEHOLDER_INFO,
             placeholderinfosize: u32,
-        ) -> windows::core::Result<()> {
+        ) -> windows::core::Result<()>
+        where
+            P0: Param<PCWSTR>,
+        {
             (self.PrjWritePlaceholderInfo)(
                 namespacevirtualizationcontext,
-                destinationfilename,
+                destinationfilename.param().abi(),
                 placeholderinfo,
                 placeholderinfosize,
             )
             .ok()
         }
 
-        unsafe fn prj_write_placeholder_info2(
+        unsafe fn prj_write_placeholder_info2<P0>(
             &self,
             namespacevirtualizationcontext: PRJ_NAMESPACE_VIRTUALIZATION_CONTEXT,
-            destinationfilename: PCWSTR,
+            destinationfilename: P0,
             placeholderinfo: *const PRJ_PLACEHOLDER_INFO,
             placeholderinfosize: u32,
             extendedinfo: Option<*const PRJ_EXTENDED_INFO>,
-        ) -> windows::core::Result<()> {
+        ) -> windows::core::Result<()>
+        where
+            P0: Param<PCWSTR>,
+        {
             (self.PrjWritePlaceholderInfo2)(
                 namespacevirtualizationcontext,
-                destinationfilename,
+                destinationfilename.param().abi(),
                 placeholderinfo,
                 placeholderinfosize,
                 extendedinfo.unwrap_or(ptr::null()),
@@ -456,7 +529,7 @@ mod lib_impl {
         }
     }
 
-    pub fn load_library() -> Result<Arc<dyn ProjectedFSLibrary>> {
+    pub fn load_library() -> Result<Arc<DynamicallyLoadedLibrary>> {
         let library = match unsafe { libloading::Library::new("projectedfslib") } {
             Ok(library) => DynamicallyLoadedLibrary::new(library)?,
             Err(error) => {

--- a/windows-projfs/src/library.rs
+++ b/windows-projfs/src/library.rs
@@ -107,10 +107,7 @@ pub use lib_impl::Library as LibraryImpl;
 
 #[cfg(not(feature = "dynamic-import"))]
 mod lib_impl {
-    use std::{
-        ffi::c_void,
-        sync::Arc,
-    };
+    use std::ffi::c_void;
 
     use windows::{
         core::{
@@ -132,6 +129,7 @@ mod lib_impl {
 
     use super::ProjectedFSLibrary;
 
+    #[derive(Clone)]
     pub struct StaticallyLinkedLibrary;
     pub use StaticallyLinkedLibrary as Library;
 
@@ -283,8 +281,8 @@ mod lib_impl {
         }
     }
 
-    pub fn load_library() -> crate::Result<Arc<StaticallyLinkedLibrary>> {
-        Ok(Arc::new(StaticallyLinkedLibrary))
+    pub fn load_library() -> crate::Result<StaticallyLinkedLibrary> {
+        Ok(StaticallyLinkedLibrary)
     }
 }
 
@@ -292,6 +290,7 @@ mod lib_impl {
 mod lib_impl {
     use std::{
         ffi::c_void,
+        ops,
         ptr,
         sync::Arc,
     };
@@ -372,9 +371,20 @@ mod lib_impl {
         }
     }
 
-    pub use DynamicallyLoadedLibrary as Library;
+    #[derive(Clone)]
+    pub struct Library {
+        inner: Arc<DynamicallyLoadedLibrary>,
+    }
 
-    impl ProjectedFSLibrary for DynamicallyLoadedLibrary {
+    impl ops::Deref for Library {
+        type Target = DynamicallyLoadedLibrary;
+
+        fn deref(&self) -> &Self::Target {
+            &self.inner
+        }
+    }
+
+    impl ProjectedFSLibrary for Library {
         unsafe fn prj_allocate_aligned_buffer(
             &self,
             namespacevirtualizationcontext: PRJ_NAMESPACE_VIRTUALIZATION_CONTEXT,
@@ -529,9 +539,11 @@ mod lib_impl {
         }
     }
 
-    pub fn load_library() -> Result<Arc<DynamicallyLoadedLibrary>> {
+    pub fn load_library() -> Result<Library> {
         let library = match unsafe { libloading::Library::new("projectedfslib") } {
-            Ok(library) => DynamicallyLoadedLibrary::new(library)?,
+            Ok(library) => Library {
+                inner: Arc::new(DynamicallyLoadedLibrary::new(library)?),
+            },
             Err(error) => {
                 return Err(match &error {
                     libloading::Error::LoadLibraryExW { .. } => {
@@ -554,7 +566,7 @@ mod lib_impl {
             }
         };
 
-        Ok(Arc::new(library))
+        Ok(library)
     }
 }
 


### PR DESCRIPTION
We don't expose the ProjectedFSLibrary internal, and so we can use our
feature flag to pick a speicific library impl instead of using dyn. This
also enables us to provide functions that match the types of the
upstream windows api functions by using generics for the PCWSTR args.
This wasn't possible with `dyn ProjectedFSLibrary` because generics in
that fashion make the trait not dyn-safe.

Getting the generics lets us use more natural patterns to supply those
PCWSTR args using HSTRING, which removes our need to manually convert to
the approrpaite string encoding (because we have HSTRING do it).

Removing dyn also is likely to make the code generated somewhat simpler
unless the compiler managed to de-virtualize.

Next, Instead of having Arc<LibraryImpl> all the time, instead push Arc down
into the dynamic-impl version, allowing us to remove the Arc for the
not(dynamic-impl) case.

This means the not(dynamic-impl) case will have no extra size overhead
(because its LibraryImpl is a zero sized type which we can clone for
free without the Arc).

Overhead of the dynamic-impl variant should be identical to previous.